### PR TITLE
fix(package): include index html

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 setup(
     name='adr-viewer',
     url='https://github.com/mrwilson/adr-viewer',
-    version='1.1.0',
+    version='1.1.1',
     description='A visualisation tool for Architecture Decision Records',
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -14,7 +14,6 @@ setup(
     author_email='a.wilson@alumni.warwick.ac.uk',
     license='MIT',
     packages=find_packages(),
-    include_package_data=True,
     install_requires=(
         'click',
         'mistune',


### PR DESCRIPTION
Reason for this change is this:

https://stackoverflow.com/a/11848281/161281

```
Do not use both include_package_data and package_data in setup.py.
include_package_data will nullify the package_data information.
```

Now, orginal package throws error (version 1.1.0):

```
Traceback (most recent call last):
  File "/Users/galuszkak/.virtualenvs/architecture-decision-record-msS_HC_8/bin/adr-viewer", line 10, in <module>
    sys.exit(main())
  File "/Users/galuszkak/.virtualenvs/architecture-decision-record-msS_HC_8/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/galuszkak/.virtualenvs/architecture-decision-record-msS_HC_8/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/galuszkak/.virtualenvs/architecture-decision-record-msS_HC_8/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/galuszkak/.virtualenvs/architecture-decision-record-msS_HC_8/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/galuszkak/.virtualenvs/architecture-decision-record-msS_HC_8/lib/python3.7/site-packages/adr_viewer/__init__.py", line 100, in main
    content = generate_content(adr_path)
  File "/Users/galuszkak/.virtualenvs/architecture-decision-record-msS_HC_8/lib/python3.7/site-packages/adr_viewer/__init__.py", line 92, in generate_content
    return render_html(config)
  File "/Users/galuszkak/.virtualenvs/architecture-decision-record-msS_HC_8/lib/python3.7/site-packages/adr_viewer/__init__.py", line 57, in render_html
    template = env.get_template('index.html')
  File "/Users/galuszkak/.virtualenvs/architecture-decision-record-msS_HC_8/lib/python3.7/site-packages/jinja2/environment.py", line 830, in get_template
    return self._load_template(name, self.make_globals(globals))
  File "/Users/galuszkak/.virtualenvs/architecture-decision-record-msS_HC_8/lib/python3.7/site-packages/jinja2/environment.py", line 804, in _load_template
    template = self.loader.load(self, name, globals)
  File "/Users/galuszkak/.virtualenvs/architecture-decision-record-msS_HC_8/lib/python3.7/site-packages/jinja2/loaders.py", line 113, in load
    source, filename, uptodate = self.get_source(environment, name)
  File "/Users/galuszkak/.virtualenvs/architecture-decision-record-msS_HC_8/lib/python3.7/site-packages/jinja2/loaders.py", line 235, in get_source
    raise TemplateNotFound(template)
jinja2.exceptions.TemplateNotFound: index.html
```