### PR TITLE
fix typo and allow list status

### DIFF
--- a/adr_viewer/__init__.py
+++ b/adr_viewer/__init__.py
@@ -35,8 +35,8 @@ def parse_adr_to_config(path):
         status = 'amended'
     elif any([line.startswith("Accepted") for line in status]):
         status = 'accepted'
-    elif any([line.startswith("Superceded by") for line in status]):
-        status = 'superceded'
+    elif any([line.startswith("Superseded by") for line in status]):
+        status = 'superseded'
     elif any([line.startswith("Pending") for line in status]):
         status = 'pending'
     else:

--- a/adr_viewer/__init__.py
+++ b/adr_viewer/__init__.py
@@ -18,6 +18,8 @@ def extract_statuses_from_adr(page_object):
 
             if current_node.name == 'p':
                 yield current_node.text
+            elif current_node.name == 'ul':
+                yield from (li.text for li in current_node.children if li.name == "li")
             else:
                 continue
 

--- a/adr_viewer/templates/index.html
+++ b/adr_viewer/templates/index.html
@@ -36,7 +36,7 @@
                 background-color: lightgreen;
             }
 
-            .panel-heading.adr-superceded {
+            .panel-heading.adr-superseded {
                 background-color: lightgrey;
             }
 
@@ -52,7 +52,7 @@
                 background-color: lightblue;
             }
 
-            .adr-superceded > .panel-title > a {
+            .adr-superseded > .panel-title > a {
                 text-decoration: line-through;
             }
 
@@ -74,7 +74,7 @@
 
                         {% if adr_record.status == "accepted" %}
                         <i class="adr-icon fas fa-fw fa-check"></i>
-                        {% elif adr_record.status == "superceded" %}
+                        {% elif adr_record.status == "superseded" %}
                         <i class="adr-icon fas fa-fw fa-times"></i>
                         {% elif adr_record.status == "amended" %}
                         <i class="adr-icon fas fa-fw fa-arrow-down"></i>

--- a/adr_viewer/test_adr_viewer.py
+++ b/adr_viewer/test_adr_viewer.py
@@ -19,14 +19,14 @@ def test_should_include_adr_as_html():
     assert '<h1>1. Record architecture decisions</h1>' in config['body']
 
 
-def test_should_mark_superceded_records():
+def test_should_mark_superseded_records():
     config = parse_adr_to_config('doc/adr/0003-use-same-colour-for-all-headers.md')
 
-    assert config['status'] == 'superceded'
+    assert config['status'] == 'superseded'
 
 
 def test_should_mark_amended_records():
-    config = parse_adr_to_config('doc/adr/0004-distinguish-superceded-records-with-colour.md')
+    config = parse_adr_to_config('doc/adr/0004-distinguish-superseded-records-with-colour.md')
 
     assert config['status'] == 'amended'
 

--- a/doc/adr/0003-use-same-colour-for-all-headers.md
+++ b/doc/adr/0003-use-same-colour-for-all-headers.md
@@ -4,7 +4,7 @@ Date: 2018-09-09
 
 ## Status
 
-Superceded by [4. Distinguish superceded records with colour](0004-distinguish-superceded-records-with-colour.md)
+Superseded by [4. Distinguish superseded records with colour](0004-distinguish-superseded-records-with-colour.md)
 
 ## Context
 

--- a/doc/adr/0004-distinguish-superseded-records-with-colour.md
+++ b/doc/adr/0004-distinguish-superseded-records-with-colour.md
@@ -1,4 +1,4 @@
-# 4. Distinguish superceded records with colour
+# 4. Distinguish superseded records with colour
 
 Date: 2018-09-09
 
@@ -16,7 +16,7 @@ Amended by [5. Distinguish amendments to records with colour](0005-distinguish-a
 
 ## Decision
 
-Records marked as 'Superceded' will distinguish themselves from 'Accepted' 
+Records marked as 'Superseded' will distinguish themselves from 'Accepted' 
 
 ## Consequences
 

--- a/doc/adr/0005-distinguish-amendments-to-records-with-colour.md
+++ b/doc/adr/0005-distinguish-amendments-to-records-with-colour.md
@@ -6,15 +6,15 @@ Date: 2018-09-09
 
 Accepted
 
-Amends [4. Distinguish superceded records with colour](0004-distinguish-superceded-records-with-colour.md)
+Amends [4. Distinguish superseded records with colour](0004-distinguish-superseded-records-with-colour.md)
 
 ## Context
 
-Architecture Decision Records may be `amended` rather than `superceded` if e.g. only a small part of the decision changes.
+Architecture Decision Records may be `amended` rather than `superseded` if e.g. only a small part of the decision changes.
 
 ## Decision
 
-Amended records, although not officially supported as a distinct flag in `adr-tools`, should be distinguished from records that are either Accepted or Superceded by.
+Amended records, although not officially supported as a distinct flag in `adr-tools`, should be distinguished from records that are either Accepted or Superseded by.
 
 ## Consequences
 


### PR DESCRIPTION
There is two fixes in this pr:

1. The correct  spelling is **supersede**, see https://grammarist.com/spelling/supersede-or-supercede/
2. Allow a list based status, for example
```markdown
## Status
* Deprecated
* Deciders: John Doe
* Date: 2019-03-14
* Accepted
* Deciders: John Doe, Jane Doe
* Date: 2019-02-14
```
the first status is always the current one, but keep the previous status dates and decider for history purposes