### PR TITLE
Fixed known CVEs in older bootstrap and jquery libs

### DIFF
--- a/adr_viewer/templates/index.html
+++ b/adr_viewer/templates/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
         <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css">
         <title>ADR Viewer - {{ config.project_title }}</title>
 


### PR DESCRIPTION
The current versions in the template file for the bootstrap and jquery libraries trigger CVE vulnerability warnings in scanning tools. The updated versions in the PR appear to be backwards compatible, yet they fix the vulnerabilities.