### PR TITLE
Add missing status Proposed

### DIFF
--- a/adr_viewer/__init__.py
+++ b/adr_viewer/__init__.py
@@ -38,7 +38,7 @@ def parse_adr_to_config(path):
         status = 'accepted'
     elif any([line.startswith("Superseded by") for line in status]):
         status = 'superseded'
-    elif any([line.startswith("Pending") for line in status]):
+    elif any([line.startswith("Proposed") or line.startswith("Pending") for line in status]):
         status = 'pending'
     else:
         status = 'unknown'

--- a/adr_viewer/test_adr_viewer.py
+++ b/adr_viewer/test_adr_viewer.py
@@ -42,6 +42,10 @@ def test_should_mark_pending_records():
 
     assert config['status'] == 'pending'
 
+def test_should_mark_pproposed_records():
+    config = parse_adr_to_config('test/adr/0004-proposed-status.md')
+
+    assert config['status'] == 'pending'
 
 def test_should_render_html_with_project_title():
     html = render_html({

--- a/test/adr/0004-proposed-status.md
+++ b/test/adr/0004-proposed-status.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2018-09-02
+
+## Status
+
+Proposed
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).


### PR DESCRIPTION
adr-viewer implements the status "Pending", but the original blog article by Michael Nygard and adr-tools-python use the status "Proposed" for new ADRs. This patch adds "Proposed" as synonyme for "Pending".