### PR TITLE
Test Python 3.7-3.11 on Travis, drop 3.6 and older

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: python
 dist: xenial
 python:
-- "2.7"
-- "3.5"
-- "3.6"
 - "3.7"
+- "3.8"
+- "3.9"
+- "3.10"
+- "3.11"
 install:
   - pip install -r requirements.txt
   - npm install -g pa11y


### PR DESCRIPTION
3.6 and older are fully EOL. 3.7 will be EOL in a few months…
