### PR TITLE
Expand GitHub Actions testing to 3.7–3.11 using build matrix

### DIFF
--- a/.github/workflows/pre-merge-checks.yaml
+++ b/.github/workflows/pre-merge-checks.yaml
@@ -10,15 +10,23 @@ on:
 
 jobs:
   pre-merge-checks:
-
+    name: Pre-merge checks (Python ${{ matrix.python_version }})
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version:
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: "${{ matrix.python_version}}"
     - name: Install dependencies
       run: |
         pip install -r requirements.txt


### PR DESCRIPTION
Also bumps checkout and setup-python versions to their latest.
