### PR TITLE
Use setuptools' SCM support to determine version from Git tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 build/
 adr_viewer.egg-info/
 .pytest_cache/
+.eggs/

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ with open("README.md", "r") as fh:
 setup(
     name='adr-viewer',
     url='https://github.com/mrwilson/adr-viewer',
-    version='1.3.0',
     description='A visualisation tool for Architecture Decision Records',
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -34,5 +33,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-    ]
+    ],
+    use_scm_version=True,
+    setup_requires=["setuptools_scm"],
 )


### PR DESCRIPTION
This of course predictates on a git tag release system but this repo seems to already be doing that.
