### PR TITLE
Let Python 3.7 rely on an older mypy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ beautifulsoup4==4.10.0
 Jinja2==3.1.2
 pytest==7.4.0
 bottle==0.12.25
-mypy==1.5.1
+mypy==1.4.1 ; python_version <= "3.7"
+mypy==1.5.1 ; python_version >= "3.8"


### PR DESCRIPTION
1.4.1 was the last release supporting Python 3.7, EOL in June 2023.