### PR TITLE
refactor: Clean up ADR parsing

### DIFF
--- a/adr_viewer/__init__.py
+++ b/adr_viewer/__init__.py
@@ -25,8 +25,8 @@ def generate_content(path, template_dir_override=None, title=None) -> str:
     }
 
     for index, adr_file in enumerate(files):
-
-        adr_attributes = parse_adr(adr_file)
+        markdown = open(adr_file).read()
+        adr_attributes = parse_adr(markdown)
 
         if adr_attributes:
             adr_attributes.index = index

--- a/adr_viewer/__init__.py
+++ b/adr_viewer/__init__.py
@@ -29,7 +29,7 @@ def generate_content(path, template_dir_override=None, title=None) -> str:
         adr_attributes = parse_adr_to_config(adr_file)
 
         if adr_attributes:
-            adr_attributes['index'] = index
+            adr_attributes.index = index
 
             config['records'].append(adr_attributes)
         else:

--- a/adr_viewer/__init__.py
+++ b/adr_viewer/__init__.py
@@ -4,7 +4,7 @@ from typing import List
 
 import click
 
-from adr_viewer.parse import parse_adr_to_config
+from adr_viewer.parse import parse_adr
 from adr_viewer.render import render_html
 from adr_viewer.server import run_server
 
@@ -26,7 +26,7 @@ def generate_content(path, template_dir_override=None, title=None) -> str:
 
     for index, adr_file in enumerate(files):
 
-        adr_attributes = parse_adr_to_config(adr_file)
+        adr_attributes = parse_adr(adr_file)
 
         if adr_attributes:
             adr_attributes.index = index

--- a/adr_viewer/parse.py
+++ b/adr_viewer/parse.py
@@ -30,8 +30,8 @@ def extract_statuses_from_adr(page_object) -> Iterator[str]:
                 continue
 
 
-def parse_adr(path) -> Optional[Adr]:
-    adr_as_html = mistune.markdown(open(path).read())
+def parse_adr(content: str) -> Optional[Adr]:
+    adr_as_html = mistune.markdown(content)
 
     soup = BeautifulSoup(adr_as_html, features='html.parser')
 

--- a/adr_viewer/parse.py
+++ b/adr_viewer/parse.py
@@ -30,7 +30,7 @@ def extract_statuses_from_adr(page_object) -> Iterator[str]:
                 continue
 
 
-def parse_adr_to_config(path) -> Optional[Dict]:
+def parse_adr_to_config(path) -> Optional[Adr]:
     adr_as_html = mistune.markdown(open(path).read())
 
     soup = BeautifulSoup(adr_as_html, features='html.parser')
@@ -51,10 +51,6 @@ def parse_adr_to_config(path) -> Optional[Dict]:
     header = soup.find('h1')
 
     if header:
-        return {
-            'status': status,
-            'body': adr_as_html,
-            'title': header.text
-        }
+        return Adr(header.text, status, adr_as_html)
     else:
         return None

--- a/adr_viewer/parse.py
+++ b/adr_viewer/parse.py
@@ -30,7 +30,7 @@ def extract_statuses_from_adr(page_object) -> Iterator[str]:
                 continue
 
 
-def parse_adr_to_config(path) -> Optional[Adr]:
+def parse_adr(path) -> Optional[Adr]:
     adr_as_html = mistune.markdown(open(path).read())
 
     soup = BeautifulSoup(adr_as_html, features='html.parser')

--- a/adr_viewer/parse.py
+++ b/adr_viewer/parse.py
@@ -1,7 +1,16 @@
 from typing import Iterator, Optional, Dict
 from bs4 import BeautifulSoup
+from dataclasses import dataclass
 
 import mistune
+
+
+@dataclass
+class Adr:
+    title: str
+    status: str
+    body: str
+    index: int = 0
 
 
 def extract_statuses_from_adr(page_object) -> Iterator[str]:

--- a/adr_viewer/test_parse.py
+++ b/adr_viewer/test_parse.py
@@ -2,54 +2,54 @@ from adr_viewer import parse_adr_to_config
 
 
 def test_should_extract_title_from_record():
-    config = parse_adr_to_config('doc/adr/0001-record-architecture-decisions.md')
+    adr = parse_adr_to_config('doc/adr/0001-record-architecture-decisions.md')
 
-    assert config['title'] == '1. Record architecture decisions'
+    assert adr.title == '1. Record architecture decisions'
 
 
 def test_should_extract_status_from_record():
-    config = parse_adr_to_config('doc/adr/0001-record-architecture-decisions.md')
+    adr = parse_adr_to_config('doc/adr/0001-record-architecture-decisions.md')
 
-    assert config['status'] == 'accepted'
+    assert adr.status == 'accepted'
 
 
 def test_should_include_adr_as_html():
-    config = parse_adr_to_config('doc/adr/0001-record-architecture-decisions.md')
+    adr = parse_adr_to_config('doc/adr/0001-record-architecture-decisions.md')
 
-    assert '<h1>1. Record architecture decisions</h1>' in config['body']
+    assert '<h1>1. Record architecture decisions</h1>' in adr.body
 
 
 def test_should_mark_superseded_records():
-    config = parse_adr_to_config('doc/adr/0003-use-same-colour-for-all-headers.md')
+    adr = parse_adr_to_config('doc/adr/0003-use-same-colour-for-all-headers.md')
 
-    assert config['status'] == 'superseded'
+    assert adr.status == 'superseded'
 
 
 def test_should_mark_amended_records():
-    config = parse_adr_to_config('doc/adr/0004-distinguish-superseded-records-with-colour.md')
+    adr = parse_adr_to_config('doc/adr/0004-distinguish-superseded-records-with-colour.md')
 
-    assert config['status'] == 'amended'
+    assert adr.status == 'amended'
 
 
 def test_should_mark_unknown_records():
-    config = parse_adr_to_config('test/adr/0001-unknown-status.md')
+    adr = parse_adr_to_config('test/adr/0001-unknown-status.md')
 
-    assert config['status'] == 'unknown'
+    assert adr.status == 'unknown'
 
 
 def test_should_mark_pending_records():
-    config = parse_adr_to_config('test/adr/0002-pending-status.md')
+    adr = parse_adr_to_config('test/adr/0002-pending-status.md')
 
-    assert config['status'] == 'pending'
+    assert adr.status == 'pending'
 
 
 def test_should_mark_pproposed_records():
-    config = parse_adr_to_config('test/adr/0004-proposed-status.md')
+    adr = parse_adr_to_config('test/adr/0004-proposed-status.md')
 
-    assert config['status'] == 'pending'
+    assert adr.status == 'pending'
 
 
 def test_should_ignore_invalid_files():
-    config = parse_adr_to_config('test/adr/0003-bad-formatting.md')
+    adr = parse_adr_to_config('test/adr/0003-bad-formatting.md')
 
-    assert config is None
+    assert adr is None

--- a/adr_viewer/test_parse.py
+++ b/adr_viewer/test_parse.py
@@ -2,54 +2,63 @@ from adr_viewer import parse_adr
 
 
 def test_should_extract_title_from_record():
-    adr = parse_adr('doc/adr/0001-record-architecture-decisions.md')
+    markdown = open('doc/adr/0001-record-architecture-decisions.md').read()
+    adr = parse_adr(markdown)
 
     assert adr.title == '1. Record architecture decisions'
 
 
 def test_should_extract_status_from_record():
-    adr = parse_adr('doc/adr/0001-record-architecture-decisions.md')
+    markdown = open('doc/adr/0001-record-architecture-decisions.md').read()
+    adr = parse_adr(markdown)
 
     assert adr.status == 'accepted'
 
 
-def test_should_include_adr_as_html():
-    adr = parse_adr('doc/adr/0001-record-architecture-decisions.md')
+def test_should_include_adr_as_markdown():
+    markdown = open('doc/adr/0001-record-architecture-decisions.md').read()
+    adr = parse_adr(markdown)
 
     assert '<h1>1. Record architecture decisions</h1>' in adr.body
 
 
 def test_should_mark_superseded_records():
-    adr = parse_adr('doc/adr/0003-use-same-colour-for-all-headers.md')
+    markdown = open('doc/adr/0003-use-same-colour-for-all-headers.md').read()
+    adr = parse_adr(markdown)
 
     assert adr.status == 'superseded'
 
 
 def test_should_mark_amended_records():
-    adr = parse_adr('doc/adr/0004-distinguish-superseded-records-with-colour.md')
+    markdown = open('doc/adr/0004-distinguish-superseded-records-with-colour.md').read()
+    adr = parse_adr(markdown)
 
     assert adr.status == 'amended'
 
 
 def test_should_mark_unknown_records():
-    adr = parse_adr('test/adr/0001-unknown-status.md')
+    markdown = open('test/adr/0001-unknown-status.md').read()
+    adr = parse_adr(markdown)
 
     assert adr.status == 'unknown'
 
 
 def test_should_mark_pending_records():
-    adr = parse_adr('test/adr/0002-pending-status.md')
+    markdown = open('test/adr/0002-pending-status.md').read()
+    adr = parse_adr(markdown)
 
     assert adr.status == 'pending'
 
 
 def test_should_mark_pproposed_records():
-    adr = parse_adr('test/adr/0004-proposed-status.md')
+    markdown = open('test/adr/0004-proposed-status.md').read()
+    adr = parse_adr(markdown)
 
     assert adr.status == 'pending'
 
 
 def test_should_ignore_invalid_files():
-    adr = parse_adr('test/adr/0003-bad-formatting.md')
+    markdown = open('test/adr/0003-bad-formatting.md').read()
+    adr = parse_adr(markdown)
 
     assert adr is None

--- a/adr_viewer/test_parse.py
+++ b/adr_viewer/test_parse.py
@@ -1,55 +1,55 @@
-from adr_viewer import parse_adr_to_config
+from adr_viewer import parse_adr
 
 
 def test_should_extract_title_from_record():
-    adr = parse_adr_to_config('doc/adr/0001-record-architecture-decisions.md')
+    adr = parse_adr('doc/adr/0001-record-architecture-decisions.md')
 
     assert adr.title == '1. Record architecture decisions'
 
 
 def test_should_extract_status_from_record():
-    adr = parse_adr_to_config('doc/adr/0001-record-architecture-decisions.md')
+    adr = parse_adr('doc/adr/0001-record-architecture-decisions.md')
 
     assert adr.status == 'accepted'
 
 
 def test_should_include_adr_as_html():
-    adr = parse_adr_to_config('doc/adr/0001-record-architecture-decisions.md')
+    adr = parse_adr('doc/adr/0001-record-architecture-decisions.md')
 
     assert '<h1>1. Record architecture decisions</h1>' in adr.body
 
 
 def test_should_mark_superseded_records():
-    adr = parse_adr_to_config('doc/adr/0003-use-same-colour-for-all-headers.md')
+    adr = parse_adr('doc/adr/0003-use-same-colour-for-all-headers.md')
 
     assert adr.status == 'superseded'
 
 
 def test_should_mark_amended_records():
-    adr = parse_adr_to_config('doc/adr/0004-distinguish-superseded-records-with-colour.md')
+    adr = parse_adr('doc/adr/0004-distinguish-superseded-records-with-colour.md')
 
     assert adr.status == 'amended'
 
 
 def test_should_mark_unknown_records():
-    adr = parse_adr_to_config('test/adr/0001-unknown-status.md')
+    adr = parse_adr('test/adr/0001-unknown-status.md')
 
     assert adr.status == 'unknown'
 
 
 def test_should_mark_pending_records():
-    adr = parse_adr_to_config('test/adr/0002-pending-status.md')
+    adr = parse_adr('test/adr/0002-pending-status.md')
 
     assert adr.status == 'pending'
 
 
 def test_should_mark_pproposed_records():
-    adr = parse_adr_to_config('test/adr/0004-proposed-status.md')
+    adr = parse_adr('test/adr/0004-proposed-status.md')
 
     assert adr.status == 'pending'
 
 
 def test_should_ignore_invalid_files():
-    adr = parse_adr_to_config('test/adr/0003-bad-formatting.md')
+    adr = parse_adr('test/adr/0003-bad-formatting.md')
 
     assert adr is None

--- a/adr_viewer/test_render.py
+++ b/adr_viewer/test_render.py
@@ -1,4 +1,5 @@
 from adr_viewer import render_html
+from adr_viewer.parse import Adr
 
 
 def test_should_render_html_with_project_title():
@@ -10,31 +11,30 @@ def test_should_render_html_with_project_title():
 
 
 def test_should_render_html_with_record_status():
+    adr = Adr('title', 'accepted', 'content')
     html = render_html({
-        'records': [{
-            'status': 'accepted',
-        }]
+        'records': [adr]
     })
 
     assert '<div class="panel-heading adr-accepted">' in html
 
 
 def test_should_render_html_with_record_body():
+    adr = Adr('title', 'status', '<h1>This is my ADR</h1>')
+
     html = render_html({
-        'records': [{
-            'body': '<h1>This is my ADR</h1>',
-        }]
+        'records': [adr]
     })
 
     assert '<div class="panel-body"><h1>This is my ADR</h1></div>' in html
 
 
 def test_should_render_html_with_collapsible_index():
+    adr = Adr('Record 123', 'status', 'content')
+    adr.index = 123
+
     html = render_html({
-        'records': [{
-            'title': 'Record 123',
-            'index': 123
-        }]
+        'records': [adr]
     })
 
     assert '<a data-toggle="collapse" href="#collapse123">Record 123</a>' in html


### PR DESCRIPTION
The code currently reads files and parses ADRs in the same place, and has a bit a of [Primitive Obsession](https://wiki.c2.com/?PrimitiveObsession) by using `dict` as a return type.

This changeset addresses both these things by introducing an `Adr` dataclass and separating file reading from parsing the ADR format.

These changes are a necessary prerequisite to implementing #52 because the parsing isn't sufficiently general.