### PR TITLE
ci: Enforce formatting with `black`

### DIFF
--- a/.github/workflows/pre-merge-checks.yaml
+++ b/.github/workflows/pre-merge-checks.yaml
@@ -30,6 +30,9 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements.txt
+    - name: Check formatting
+      run: black --check adr_viewer
+      if: ${{ matrix.python_version >= 3.8 }}
     - name: Run tests
       run: pytest
     - name: Run typecheck

--- a/adr_viewer/__init__.py
+++ b/adr_viewer/__init__.py
@@ -2,7 +2,7 @@ import glob
 import os
 from typing import List
 
-import click
+from click import option, command
 
 from adr_viewer.parse import parse_adr
 from adr_viewer.render import render_html
@@ -16,12 +16,11 @@ def get_adr_files(path) -> List[str]:
 
 
 def generate_content(path, template_dir_override=None, title=None) -> str:
-
     files = get_adr_files("%s/*.md" % path)
 
     config = {
-        'project_title': title if title else os.path.basename(os.getcwd()),
-        'records': []
+        "project_title": title if title else os.path.basename(os.getcwd()),
+        "records": [],
     }
 
     for index, adr_file in enumerate(files):
@@ -31,25 +30,27 @@ def generate_content(path, template_dir_override=None, title=None) -> str:
         if adr_attributes:
             adr_attributes.index = index
 
-            config['records'].append(adr_attributes)
+            config["records"].append(adr_attributes)
         else:
             print("Could not parse %s in ADR format, ignoring." % adr_file)
 
     return render_html(config, template_dir_override)
 
 
-@click.command()
-@click.option('--adr-path',      default='doc/adr/',   help='Directory containing ADR files.',         show_default=True)
-@click.option('--output',        default='index.html', help='File to write output to.',                show_default=True)
-@click.option('--title',         default=None,         help='Set the project title',                   show_default=True)
-@click.option('--serve',         default=False,        help='Serve content at http://localhost:8000/', is_flag=True)
-@click.option('--port',          default=8000,         help='Change port for the server',              show_default=True)
-@click.option('--template-dir',  default=None,         help='Template directory.',                     show_default=True)
+# fmt: off
+@command()
+@option('--adr-path',      default='doc/adr/',   help='Directory containing ADR files.',         show_default=True)
+@option('--output',        default='index.html', help='File to write output to.',                show_default=True)
+@option('--title',         default=None,         help='Set the project title',                   show_default=True)
+@option('--serve',         default=False,        help='Serve content at http://localhost:8000/', is_flag=True)
+@option('--port',          default=8000,         help='Change port for the server',              show_default=True)
+@option('--template-dir',  default=None,         help='Template directory.',                     show_default=True)
+# fmt: on
 def main(adr_path, output, title, serve, port, template_dir) -> None:
     content = generate_content(adr_path, template_dir, title)
 
     if serve:
         run_server(content, port)
     else:
-        with open(output, 'w') as out:
+        with open(output, "w") as out:
             out.write(content)

--- a/adr_viewer/parse.py
+++ b/adr_viewer/parse.py
@@ -14,17 +14,17 @@ class Adr:
 
 
 def extract_statuses_from_adr(page_object) -> Iterator[str]:
-    status_section = page_object.find('h2', text='Status')
+    status_section = page_object.find("h2", text="Status")
 
     if status_section and status_section.nextSibling:
         current_node = status_section.nextSibling
 
-        while current_node.name != 'h2' and current_node.nextSibling:
+        while current_node.name != "h2" and current_node.nextSibling:
             current_node = current_node.nextSibling
 
-            if current_node.name == 'p':
+            if current_node.name == "p":
                 yield current_node.text
-            elif current_node.name == 'ul':
+            elif current_node.name == "ul":
                 yield from (li.text for li in current_node.children if li.name == "li")
             else:
                 continue
@@ -33,22 +33,24 @@ def extract_statuses_from_adr(page_object) -> Iterator[str]:
 def parse_adr(content: str) -> Optional[Adr]:
     adr_as_html = mistune.markdown(content)
 
-    soup = BeautifulSoup(adr_as_html, features='html.parser')
+    soup = BeautifulSoup(adr_as_html, features="html.parser")
 
     statuses = list(extract_statuses_from_adr(soup))
 
     if any([line.startswith("Amended by") for line in statuses]):
-        status = 'amended'
+        status = "amended"
     elif any([line.startswith("Accepted") for line in statuses]):
-        status = 'accepted'
+        status = "accepted"
     elif any([line.startswith("Superseded by") for line in statuses]):
-        status = 'superseded'
-    elif any([line.startswith("Proposed") or line.startswith("Pending") for line in statuses]):
-        status = 'pending'
+        status = "superseded"
+    elif any(
+        [line.startswith("Proposed") or line.startswith("Pending") for line in statuses]
+    ):
+        status = "pending"
     else:
-        status = 'unknown'
+        status = "unknown"
 
-    header = soup.find('h1')
+    header = soup.find("h1")
 
     if header:
         return Adr(header.text, status, adr_as_html)

--- a/adr_viewer/render.py
+++ b/adr_viewer/render.py
@@ -1,14 +1,20 @@
 from jinja2 import Environment, PackageLoader, select_autoescape
-from jinja2.loaders import FileSystemLoader
+from jinja2.loaders import FileSystemLoader, BaseLoader
 
 
 def render_html(config, template_dir_override=None) -> str:
+    loader: BaseLoader
+
+    if template_dir_override:
+        loader = FileSystemLoader(template_dir_override)
+    else:
+        loader = PackageLoader("adr_viewer", "templates")
 
     env = Environment(
-        loader=PackageLoader('adr_viewer', 'templates') if template_dir_override is None else FileSystemLoader(template_dir_override),
-        autoescape=select_autoescape(['html', 'xml'])
+        loader=loader,
+        autoescape=select_autoescape(["html", "xml"]),
     )
 
-    template = env.get_template('index.html')
+    template = env.get_template("index.html")
 
     return template.render(config=config)

--- a/adr_viewer/server.py
+++ b/adr_viewer/server.py
@@ -2,7 +2,7 @@ from bottle import Bottle, run
 
 
 def run_server(content, port) -> None:
-    print(f'Starting server at http://localhost:{port}/')
+    print(f"Starting server at http://localhost:{port}/")
     app = Bottle()
-    app.route('/', 'GET', lambda: content)
-    run(app, host='localhost', port=port, quiet=True)
+    app.route("/", "GET", lambda: content)
+    run(app, host="localhost", port=port, quiet=True)

--- a/adr_viewer/test_parse.py
+++ b/adr_viewer/test_parse.py
@@ -2,63 +2,63 @@ from adr_viewer import parse_adr
 
 
 def test_should_extract_title_from_record():
-    markdown = open('doc/adr/0001-record-architecture-decisions.md').read()
+    markdown = open("doc/adr/0001-record-architecture-decisions.md").read()
     adr = parse_adr(markdown)
 
-    assert adr.title == '1. Record architecture decisions'
+    assert adr.title == "1. Record architecture decisions"
 
 
 def test_should_extract_status_from_record():
-    markdown = open('doc/adr/0001-record-architecture-decisions.md').read()
+    markdown = open("doc/adr/0001-record-architecture-decisions.md").read()
     adr = parse_adr(markdown)
 
-    assert adr.status == 'accepted'
+    assert adr.status == "accepted"
 
 
 def test_should_include_adr_as_markdown():
-    markdown = open('doc/adr/0001-record-architecture-decisions.md').read()
+    markdown = open("doc/adr/0001-record-architecture-decisions.md").read()
     adr = parse_adr(markdown)
 
-    assert '<h1>1. Record architecture decisions</h1>' in adr.body
+    assert "<h1>1. Record architecture decisions</h1>" in adr.body
 
 
 def test_should_mark_superseded_records():
-    markdown = open('doc/adr/0003-use-same-colour-for-all-headers.md').read()
+    markdown = open("doc/adr/0003-use-same-colour-for-all-headers.md").read()
     adr = parse_adr(markdown)
 
-    assert adr.status == 'superseded'
+    assert adr.status == "superseded"
 
 
 def test_should_mark_amended_records():
-    markdown = open('doc/adr/0004-distinguish-superseded-records-with-colour.md').read()
+    markdown = open("doc/adr/0004-distinguish-superseded-records-with-colour.md").read()
     adr = parse_adr(markdown)
 
-    assert adr.status == 'amended'
+    assert adr.status == "amended"
 
 
 def test_should_mark_unknown_records():
-    markdown = open('test/adr/0001-unknown-status.md').read()
+    markdown = open("test/adr/0001-unknown-status.md").read()
     adr = parse_adr(markdown)
 
-    assert adr.status == 'unknown'
+    assert adr.status == "unknown"
 
 
 def test_should_mark_pending_records():
-    markdown = open('test/adr/0002-pending-status.md').read()
+    markdown = open("test/adr/0002-pending-status.md").read()
     adr = parse_adr(markdown)
 
-    assert adr.status == 'pending'
+    assert adr.status == "pending"
 
 
 def test_should_mark_pproposed_records():
-    markdown = open('test/adr/0004-proposed-status.md').read()
+    markdown = open("test/adr/0004-proposed-status.md").read()
     adr = parse_adr(markdown)
 
-    assert adr.status == 'pending'
+    assert adr.status == "pending"
 
 
 def test_should_ignore_invalid_files():
-    markdown = open('test/adr/0003-bad-formatting.md').read()
+    markdown = open("test/adr/0003-bad-formatting.md").read()
     adr = parse_adr(markdown)
 
     assert adr is None

--- a/adr_viewer/test_render.py
+++ b/adr_viewer/test_render.py
@@ -3,38 +3,30 @@ from adr_viewer.parse import Adr
 
 
 def test_should_render_html_with_project_title():
-    html = render_html({
-        'project_title': 'my-project'
-    })
+    html = render_html({"project_title": "my-project"})
 
-    assert '<title>ADR Viewer - my-project</title>' in html
+    assert "<title>ADR Viewer - my-project</title>" in html
 
 
 def test_should_render_html_with_record_status():
-    adr = Adr('title', 'accepted', 'content')
-    html = render_html({
-        'records': [adr]
-    })
+    adr = Adr("title", "accepted", "content")
+    html = render_html({"records": [adr]})
 
     assert '<div class="panel-heading adr-accepted">' in html
 
 
 def test_should_render_html_with_record_body():
-    adr = Adr('title', 'status', '<h1>This is my ADR</h1>')
+    adr = Adr("title", "status", "<h1>This is my ADR</h1>")
 
-    html = render_html({
-        'records': [adr]
-    })
+    html = render_html({"records": [adr]})
 
     assert '<div class="panel-body"><h1>This is my ADR</h1></div>' in html
 
 
 def test_should_render_html_with_collapsible_index():
-    adr = Adr('Record 123', 'status', 'content')
+    adr = Adr("Record 123", "status", "content")
     adr.index = 123
 
-    html = render_html({
-        'records': [adr]
-    })
+    html = render_html({"records": [adr]})
 
     assert '<a data-toggle="collapse" href="#collapse123">Record 123</a>' in html

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pytest==7.4.2
 bottle==0.12.25
 mypy==1.4.1 ; python_version <= "3.7"
 mypy==1.5.1 ; python_version >= "3.8"
+black==23.9.0 ; python_version >= "3.8"


### PR DESCRIPTION
Coding standards shouldn't be a discussion point, so this change will apply `black` to the code and add a formatting check as part of the pre-merge actions