### PR TITLE
chore: Remove 3.7 support

### DIFF
--- a/.github/workflows/pre-merge-checks.yaml
+++ b/.github/workflows/pre-merge-checks.yaml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         python_version:
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
@@ -32,7 +31,6 @@ jobs:
         pip install -r requirements.txt
     - name: Check formatting
       run: black --check adr_viewer
-      if: ${{ matrix.python_version >= 3.8 }}
     - name: Run tests
       run: pytest
     - name: Run typecheck

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ beautifulsoup4==4.12.2
 Jinja2==3.1.2
 pytest==7.4.2
 bottle==0.12.25
-mypy==1.4.1 ; python_version <= "3.7"
-mypy==1.5.1 ; python_version >= "3.8"
-black==23.9.0 ; python_version >= "3.8"
+mypy==1.5.1
+black==23.9.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Topic :: Software Development',
         'Topic :: Software Development :: Documentation',
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
     ],

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ setup(
         'Topic :: Software Development :: Documentation',
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     use_scm_version=True,
     setup_requires=["setuptools_scm"],


### PR DESCRIPTION
Python 3.7 is out of support now, and we had to work around dependencies to support it.

This change removes support for 3.7 and cleans up the dependencies because of that.