### PR TITLE
refactor: Add typing to (and smarten up) render logic

### DIFF
--- a/adr_viewer/__init__.py
+++ b/adr_viewer/__init__.py
@@ -5,7 +5,7 @@ from typing import List
 from click import option, command
 
 from adr_viewer.parse import parse_adr
-from adr_viewer.render import render_html
+from adr_viewer.render import render_html, AdrTemplateConfig
 from adr_viewer.server import run_server
 
 
@@ -18,11 +18,9 @@ def get_adr_files(path) -> List[str]:
 def generate_content(path, template_dir_override=None, title=None) -> str:
     files = get_adr_files("%s/*.md" % path)
 
-    config = {
-        "project_title": title if title else os.path.basename(os.getcwd()),
-        "records": [],
-        "include_mermaid": False,
-    }
+    config = AdrTemplateConfig(
+        project_title=title if title else os.path.basename(os.getcwd()), records=[]
+    )
 
     for index, adr_file in enumerate(files):
         markdown = open(adr_file).read()
@@ -30,10 +28,10 @@ def generate_content(path, template_dir_override=None, title=None) -> str:
 
         if adr_attributes:
             adr_attributes.index = index
-            if not config["include_mermaid"]:
-                config["include_mermaid"] = adr_attributes.includes_mermaid
+            if not config.include_mermaid:
+                config.include_mermaid = adr_attributes.includes_mermaid
 
-            config["records"].append(adr_attributes)
+            config.records.append(adr_attributes)
         else:
             print("Could not parse %s in ADR format, ignoring." % adr_file)
 

--- a/adr_viewer/__init__.py
+++ b/adr_viewer/__init__.py
@@ -8,12 +8,10 @@ from adr_viewer.render import render_html, AdrTemplateConfig
 from adr_viewer.server import run_server
 
 
-def generate_content(path, template_dir_override=None, title=None) -> str:
+def generate_content(adrs: List[Adr], template_dir_override=None, title=None) -> str:
     config = AdrTemplateConfig(
         project_title=title if title else os.path.basename(os.getcwd()), records=[]
     )
-
-    adrs: List[Adr] = parse_adr_files("%s/*.md" % path)
 
     for index, adr in enumerate(adrs):
         adr.index = index
@@ -34,7 +32,9 @@ def generate_content(path, template_dir_override=None, title=None) -> str:
 @option('--template-dir',  default=None,         help='Template directory.',                     show_default=True)
 # fmt: on
 def main(adr_path, output, title, serve, port, template_dir) -> None:
-    content = generate_content(adr_path, template_dir, title)
+    adrs: List[Adr] = parse_adr_files("%s/*.md" % adr_path)
+
+    content = generate_content(adrs, template_dir, title)
 
     if serve:
         run_server(content, port)

--- a/adr_viewer/__init__.py
+++ b/adr_viewer/__init__.py
@@ -28,8 +28,7 @@ def generate_content(path, template_dir_override=None, title=None) -> str:
 
         if adr_attributes:
             adr_attributes.index = index
-            if not config.include_mermaid:
-                config.include_mermaid = adr_attributes.includes_mermaid
+            adr_attributes.includes_mermaid |= config.include_mermaid
 
             config.records.append(adr_attributes)
         else:

--- a/adr_viewer/__init__.py
+++ b/adr_viewer/__init__.py
@@ -24,13 +24,13 @@ def generate_content(path, template_dir_override=None, title=None) -> str:
 
     for index, adr_file in enumerate(files):
         markdown = open(adr_file).read()
-        adr_attributes = parse_adr(markdown)
+        adr = parse_adr(markdown)
 
-        if adr_attributes:
-            adr_attributes.index = index
-            adr_attributes.includes_mermaid |= config.include_mermaid
+        if adr:
+            adr.index = index
+            adr.includes_mermaid |= config.include_mermaid
 
-            config.records.append(adr_attributes)
+            config.records.append(adr)
         else:
             print("Could not parse %s in ADR format, ignoring." % adr_file)
 

--- a/adr_viewer/__init__.py
+++ b/adr_viewer/__init__.py
@@ -1,25 +1,10 @@
-import os
 from typing import List
 
 from click import option, command
 
 from adr_viewer.parse import parse_adr, parse_adr_files, Adr
-from adr_viewer.render import render_html, AdrTemplateConfig
+from adr_viewer.render import render_html, AdrTemplateConfig, generate_content
 from adr_viewer.server import run_server
-
-
-def generate_content(adrs: List[Adr], template_dir_override=None, title=None) -> str:
-    config = AdrTemplateConfig(
-        project_title=title if title else os.path.basename(os.getcwd()), records=[]
-    )
-
-    for index, adr in enumerate(adrs):
-        adr.index = index
-        adr.includes_mermaid |= config.include_mermaid
-
-        config.records.append(adr)
-
-    return render_html(config, template_dir_override)
 
 
 # fmt: off

--- a/adr_viewer/__init__.py
+++ b/adr_viewer/__init__.py
@@ -1,38 +1,25 @@
-import glob
 import os
 from typing import List
 
 from click import option, command
 
-from adr_viewer.parse import parse_adr
+from adr_viewer.parse import parse_adr, parse_adr_files, Adr
 from adr_viewer.render import render_html, AdrTemplateConfig
 from adr_viewer.server import run_server
 
 
-def get_adr_files(path) -> List[str]:
-    files = glob.glob(path)
-    files.sort()
-    return files
-
-
 def generate_content(path, template_dir_override=None, title=None) -> str:
-    files = get_adr_files("%s/*.md" % path)
-
     config = AdrTemplateConfig(
         project_title=title if title else os.path.basename(os.getcwd()), records=[]
     )
 
-    for index, adr_file in enumerate(files):
-        markdown = open(adr_file).read()
-        adr = parse_adr(markdown)
+    adrs: List[Adr] = parse_adr_files("%s/*.md" % path)
 
-        if adr:
-            adr.index = index
-            adr.includes_mermaid |= config.include_mermaid
+    for index, adr in enumerate(adrs):
+        adr.index = index
+        adr.includes_mermaid |= config.include_mermaid
 
-            config.records.append(adr)
-        else:
-            print("Could not parse %s in ADR format, ignoring." % adr_file)
+        config.records.append(adr)
 
     return render_html(config, template_dir_override)
 

--- a/adr_viewer/parse.py
+++ b/adr_viewer/parse.py
@@ -1,4 +1,5 @@
-from typing import Iterator, Optional, Dict
+import glob
+from typing import Iterator, Optional, List
 from bs4 import BeautifulSoup
 from dataclasses import dataclass
 
@@ -29,6 +30,26 @@ def extract_statuses_from_adr(page_object) -> Iterator[str]:
                 yield from (li.text for li in current_node.children if li.name == "li")
             else:
                 continue
+
+
+def parse_adr_files(path: str) -> List[Adr]:
+    files: List[str] = glob.glob(path)
+    files.sort()
+
+    adrs: List[Adr] = []
+
+    for file in files:
+        content = open(file).read()
+
+        adr = parse_adr(content)
+
+        if not adr:
+            print("Could not parse %s in ADR format, ignoring." % file)
+            continue
+
+        adrs.append(adr)
+
+    return adrs
 
 
 def parse_adr(content: str) -> Optional[Adr]:

--- a/adr_viewer/render.py
+++ b/adr_viewer/render.py
@@ -1,5 +1,17 @@
+from dataclasses import dataclass
+from typing import List
+
 from jinja2 import Environment, PackageLoader, select_autoescape
 from jinja2.loaders import FileSystemLoader, BaseLoader
+
+from adr_viewer.parse import Adr
+
+
+@dataclass
+class AdrTemplateConfig:
+    project_title: str
+    records: List[Adr]
+    include_mermaid: bool = False
 
 
 def render_html(config, template_dir_override=None) -> str:

--- a/adr_viewer/render.py
+++ b/adr_viewer/render.py
@@ -14,7 +14,7 @@ class AdrTemplateConfig:
     include_mermaid: bool = False
 
 
-def render_html(config, template_dir_override=None) -> str:
+def render_html(config: AdrTemplateConfig, template_dir_override=None) -> str:
     loader: BaseLoader
 
     if template_dir_override:

--- a/adr_viewer/render.py
+++ b/adr_viewer/render.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass
 from typing import List
 
@@ -30,3 +31,17 @@ def render_html(config: AdrTemplateConfig, template_dir_override=None) -> str:
     template = env.get_template("index.html")
 
     return template.render(config=config)
+
+
+def generate_content(adrs: List[Adr], template_dir_override=None, title=None) -> str:
+    config = AdrTemplateConfig(
+        project_title=title if title else os.path.basename(os.getcwd()), records=[]
+    )
+
+    for index, adr in enumerate(adrs):
+        adr.index = index
+        adr.includes_mermaid |= config.include_mermaid
+
+        config.records.append(adr)
+
+    return render_html(config, template_dir_override)

--- a/adr_viewer/test_render.py
+++ b/adr_viewer/test_render.py
@@ -1,16 +1,16 @@
-from adr_viewer import render_html
+from adr_viewer import render_html, AdrTemplateConfig
 from adr_viewer.parse import Adr
 
 
 def test_should_render_html_with_project_title():
-    html = render_html({"project_title": "my-project"})
+    html = render_html(AdrTemplateConfig(project_title="my-project", records=[]))
 
     assert "<title>ADR Viewer - my-project</title>" in html
 
 
 def test_should_render_html_with_record_status():
     adr = Adr("title", "accepted", "content")
-    html = render_html({"records": [adr]})
+    html = render_html(AdrTemplateConfig(project_title="my-project", records=[adr]))
 
     assert '<div class="panel-heading adr-accepted">' in html
 
@@ -18,7 +18,7 @@ def test_should_render_html_with_record_status():
 def test_should_render_html_with_record_body():
     adr = Adr("title", "status", "<h1>This is my ADR</h1>")
 
-    html = render_html({"records": [adr]})
+    html = render_html(AdrTemplateConfig(project_title="my-project", records=[adr]))
 
     assert '<div class="panel-body"><h1>This is my ADR</h1></div>' in html
 
@@ -27,18 +27,22 @@ def test_should_render_html_with_collapsible_index():
     adr = Adr("Record 123", "status", "content")
     adr.index = 123
 
-    html = render_html({"records": [adr]})
+    html = render_html(AdrTemplateConfig(project_title="my-project", records=[adr]))
 
     assert '<a data-toggle="collapse" href="#collapse123">Record 123</a>' in html
 
 
 def test_should_render_html_with_mermaid():
-    html = render_html({"include_mermaid": True})
+    html = render_html(
+        AdrTemplateConfig(project_title="my-project", records=[], include_mermaid=True)
+    )
 
     assert "mermaid.min.js" in html
 
 
 def test_should_render_html_without_mermaid():
-    html = render_html({"include_mermaid": False})
+    html = render_html(
+        AdrTemplateConfig(project_title="my-project", records=[], include_mermaid=False)
+    )
 
     assert "mermaid.min.js" not in html


### PR DESCRIPTION
This PR adds some typing to the content rendering logic, and pulls almost everything out of `__init__.py` apart from `main()`.

Implementation of #52 can start now