### PR TITLE
Fix the ordering of |= to determine config.include_mermaid

### DIFF
--- a/adr_viewer/render.py
+++ b/adr_viewer/render.py
@@ -2,10 +2,9 @@ import os
 from dataclasses import dataclass
 from typing import List
 
-from jinja2 import Environment, PackageLoader, select_autoescape
-from jinja2.loaders import FileSystemLoader, BaseLoader
-
 from adr_viewer.parse import Adr
+from jinja2 import Environment, PackageLoader, select_autoescape
+from jinja2.loaders import BaseLoader, FileSystemLoader
 
 
 @dataclass
@@ -40,7 +39,7 @@ def generate_content(adrs: List[Adr], template_dir_override=None, title=None) ->
 
     for index, adr in enumerate(adrs):
         adr.index = index
-        adr.includes_mermaid |= config.include_mermaid
+        config.include_mermaid |= adr.includes_mermaid
 
         config.records.append(adr)
 


### PR DESCRIPTION
Need to assign the value from `adr.includes_mermaid` to `config.include_mermaid` for any `adr` in the list.